### PR TITLE
add mojo parameter "lifecycleMappingMetadata" to succeed IntellijIdea pom validation

### DIFF
--- a/src/main/java/org/eclipse/m2e/MyMojo.java
+++ b/src/main/java/org/eclipse/m2e/MyMojo.java
@@ -19,6 +19,8 @@ package org.eclipse.m2e;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 
+import java.util.List;
+
 /**
  * Goal which just spits out info.
  * 
@@ -26,6 +28,14 @@ import org.apache.maven.plugin.MojoExecutionException;
  * 
  */
 public class MyMojo extends AbstractMojo {
+
+    /**
+     * fake parameter to make Intellij Idea pom plugin validation succeed
+     *
+     * @parameter
+     */
+    private List lifecycleMappingMetadata;
+
     /** {@inheritDoc} */
     public void execute() throws MojoExecutionException {
         getLog().info("See http://stackoverflow.com/questions/7905501/get-rid-of-pom-not-found-warning-for-org-eclipse-m2elifecycle-mapping/8741403#8741403");


### PR DESCRIPTION
IntellijIdea look at lifecycle-mapping-1.0.0/META-INF/maven/plugin.xml plugin.mojos.mojo.parameters.parameter to validate configuration section in maven pluginsl.

If parameter is <type>java.util.List</type>, than childrens is not validated.

That is why I added "lifecycleMappingMetadata" parameter as List.
